### PR TITLE
fix: add allow-dirty to dist config for custom workflow steps

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,6 +7,8 @@ members = ["cargo:."]
 cargo-dist-version = "0.30.0"
 # CI backends to support
 ci = "github"
+# Allow modified workflow files (we have custom publishing steps)
+allow-dirty = ["ci"]
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)


### PR DESCRIPTION
This fixes the release workflow failure by allowing cargo-dist to work with our customized release.yml that includes additional publishing steps.