### PR TITLE
chore: update version to 0.4.0 for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curlpit"
-version = "0.0.0-dev"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/curlpit-sh/cli"
 


### PR DESCRIPTION
Updates the Cargo.toml version to match the release tag v0.4.0