### PR TITLE
fix: update Cargo.lock for version 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "curlpit"
-version = "0.0.0-dev"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",


### PR DESCRIPTION
Updates Cargo.lock to reflect the version change to 0.4.0 to fix clippy --locked error in CI