### PR TITLE
fix: skip postinstall scripts during CI to fix npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,7 +361,7 @@ jobs:
         run: bun packages/scripts/bin/bump-version.ts "$RELEASE_VERSION"
       - name: Install workspace dependencies
         working-directory: packages
-        run: bun install
+        run: bun install --ignore-scripts
       - name: Build npm package
         working-directory: packages/npm
         run: bun run build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ cli = [
     "dep:hex",
     "dep:petname",
     "dep:shell-words",
-    "dep:curl-parser"
+    "dep:curl-parser",
 ]
 web = []
 
@@ -36,8 +36,19 @@ thiserror = "1.0"
 clap = { version = "4.5", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 dotenvy = { version = "0.15", optional = true }
-reqwest = { version = "0.12", features = ["json", "stream", "multipart", "native-tls", "gzip", "brotli"], optional = true }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"], optional = true }
+reqwest = { version = "0.12", features = [
+    "json",
+    "stream",
+    "multipart",
+    "native-tls",
+    "gzip",
+    "brotli",
+], optional = true }
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "macros",
+    "fs",
+], optional = true }
 walkdir = { version = "2", optional = true }
 chrono = { version = "0.4", features = ["serde"], optional = true }
 colored = { version = "2", optional = true }

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,13 @@ allow-dirty = ["ci"]
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program

--- a/packages/npm/src/run.ts
+++ b/packages/npm/src/run.ts
@@ -4,10 +4,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  createEnvReader,
-  determineBinaryName,
-} from "@curlpit/scripts";
+import { createEnvReader, determineBinaryName } from "@curlpit/scripts";
 
 function main() {
   const envReader = createEnvReader();
@@ -32,7 +29,7 @@ function main() {
   if (!binaryPath) {
     console.error(
       `curlpit binary is missing. Expected at ${candidatePaths.join(" or ")}.
-Try reinstalling the package or run \"npm rebuild curlpit\".`,
+Try reinstalling the package or run "npm rebuild curlpit".`,
     );
     process.exit(1);
   }

--- a/packages/scripts/src/env.ts
+++ b/packages/scripts/src/env.ts
@@ -3,7 +3,11 @@ import type { EnvReader } from "./types";
 
 const maybeDenoEnv = (() => {
   try {
-    const deno = (globalThis as { Deno?: { env?: { get(name: string): string | undefined } } }).Deno;
+    const deno = (
+      globalThis as {
+        Deno?: { env?: { get(name: string): string | undefined } };
+      }
+    ).Deno;
     return deno?.env;
   } catch {
     return undefined;
@@ -12,6 +16,7 @@ const maybeDenoEnv = (() => {
 
 export function createEnvReader(): EnvReader {
   return (key: string) => {
+    // biome-ignore lint/complexity/useOptionalChain: Skip
     if (typeof process !== "undefined" && process.env && key in process.env) {
       return process.env[key];
     }
@@ -24,6 +29,7 @@ export function guessHomeDir(env: EnvReader): string {
 }
 
 export function inferPlatform(env: EnvReader): string {
+  // biome-ignore lint/complexity/useOptionalChain: Skip
   if (typeof process !== "undefined" && process.platform) {
     return process.platform;
   }
@@ -31,6 +37,7 @@ export function inferPlatform(env: EnvReader): string {
 }
 
 export function inferArch(env: EnvReader): string {
+  // biome-ignore lint/complexity/useOptionalChain: Skip
   if (typeof process !== "undefined" && process.arch) {
     return process.arch;
   }


### PR DESCRIPTION
Fixes the npm publish step in the release workflow by adding --ignore-scripts flag to bun install. This prevents the postinstall script from trying to run dist/install.js before it has been built.