### PR TITLE
feat: switch to npm Trusted Publisher for secure publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,9 +372,7 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Publish to npm
         working-directory: packages/npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --access public --provenance
       - name: Set up Deno
         uses: denoland/setup-deno@v1
         with:


### PR DESCRIPTION
## Changes
- Remove NPM_TOKEN requirement from GitHub Actions workflow
- Add --provenance flag for signed provenance statements
- Uses GitHub OIDC tokens directly with npm's Trusted Publisher feature

## Benefits
- More secure: No long-lived tokens to manage or rotate
- Better provenance: Packages are signed and verifiable
- Simpler: No need to manage secrets in GitHub

## Prerequisites
You've already configured npm Trusted Publisher in your npm package settings to trust this GitHub repository and workflow.