### PR TITLE
fix: add version bumping to build-local-artifacts jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,13 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - name: Set release version env
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
+      - name: Apply release version bumps
+        run: bun packages/scripts/bin/bump-version.ts "$RELEASE_VERSION"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest


### PR DESCRIPTION
## Problem\nThe build-local-artifacts jobs were failing because they were building with version 0.0.0-dev instead of the actual release version.\n\n## Solution  \nAdded the bump-version.ts script execution to all build-local-artifacts jobs so they build with the correct version from the git tag.