### PR TITLE
fix: force bash shell for bump-version script on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
       - name: Apply release version bumps
+        shell: bash
         run: bun packages/scripts/bin/bump-version.ts "$RELEASE_VERSION"
       - name: Install dist
         # we specify bash to get pipefail; it guards against the `curl` command
@@ -183,6 +184,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
       - name: Apply release version bumps
+        shell: bash
         run: bun packages/scripts/bin/bump-version.ts "$RELEASE_VERSION"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
@@ -241,6 +243,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
       - name: Apply release version bumps
+        shell: bash
         run: bun packages/scripts/bin/bump-version.ts "$RELEASE_VERSION"
       - name: Install cached dist
         uses: actions/download-artifact@v4
@@ -297,6 +300,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
       - name: Apply release version bumps
+        shell: bash
         run: bun packages/scripts/bin/bump-version.ts "$RELEASE_VERSION"
       - name: Install cached dist
         uses: actions/download-artifact@v4
@@ -366,6 +370,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
       - name: Apply release version bumps
+        shell: bash
         run: bun packages/scripts/bin/bump-version.ts "$RELEASE_VERSION"
       - name: Install workspace dependencies
         working-directory: packages


### PR DESCRIPTION
## Problem\nThe Windows build was still failing because the bump-version script was running in PowerShell where `$RELEASE_VERSION` doesn't expand environment variables correctly.\n\n## Solution\nForce bash shell for the bump-version script on all platforms to ensure consistent variable expansion.\n\n## Details\n- PowerShell requires `$env:RELEASE_VERSION` syntax\n- Bash uses `$RELEASE_VERSION` syntax\n- By forcing bash shell, we ensure the script works on all platforms